### PR TITLE
Block "Enhance your Discord experience!" banner

### DIFF
--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -14,3 +14,6 @@ discord.com##div[aria-label="Add Super Reaction"]
 
 ! Block "Add Super Reaction" in message actions menu.
 discord.com###message-actions-add-reaction-1
+
+! Block "Enhance your Discord experience!" banner.
+discord.com##div[class*=" colorPremium-"]


### PR DESCRIPTION
Fixes https://github.com/synthead/discord-adfree/issues/1!

This PR blocks the Nitro upsell banner that contains the text "Enhance your Discord experience!" like so:

![image](https://user-images.githubusercontent.com/820984/236954465-989a41cd-f48c-4652-99e3-1157943a4cc9.png)