### PR TITLE
Block "Try out Nitro!" in user profile editor

### DIFF
--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -17,3 +17,6 @@ discord.com###message-actions-add-reaction-1
 
 ! Block "Enhance your Discord experience!" banner.
 discord.com##div[class*=" colorPremium-"]
+
+! Block "Try out Nitro!" in user profile editor.
+discord.com##div[class^="premiumFeatureBorder-"]:has(div[class^="premiumBackground"])

--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -19,4 +19,4 @@ discord.com###message-actions-add-reaction-1
 discord.com##div[class*=" colorPremium-"]
 
 ! Block "Try out Nitro!" in user profile editor.
-discord.com##div[class^="premiumFeatureBorder-"]:has(div[class^="premiumBackground"])
+discord.com##div[class^="premiumFeatureBorder-"]:has(div[class^="premiumBackground-"])


### PR DESCRIPTION
Fixes https://github.com/synthead/discord-adfree/issues/3!

This PR blocks the "Try out Nitro!" ad in the user profile editor:

![image](https://github.com/synthead/discord-adfree/assets/820984/777e7c79-cfa1-4332-9239-3fe043e703e2)