### PR TITLE
Block add super reaction in message context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Here's a little adblock list to hide Nitro upsell buttons in Discord!  You can s
 
 To add this list to uBlock Origin, open uBlock's settings page and click on the "Filter lists" tab.  At the bottom of the page, expand the "Custom" tree and check the "Import..." box.  Then, add this URL to the textarea that appears:
 
-    https://raw.githubusercontent.com/synthead/discord-adfree/master/discord-adfree.txt
+    https://raw.githubusercontent.com/synthead/discord-adfree/main/discord-adfree.txt
 
 Click the "Apply changes" button on the top-left of the page, and you're done!  This URL reflects the latest commit to this list, so your ad blocker will auto-update accordingly.
 

--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -15,6 +15,9 @@ discord.com##div[aria-label="Add Super Reaction"]
 ! Block "Add Super Reaction" in message actions menu.
 discord.com###message-actions-add-reaction-1
 
+! Block "Add Super Reaction" in message context menu.
+discord.com###message-add-reaction-1
+
 ! Block "Enhance your Discord experience!" banner.
 discord.com##div[class*=" colorPremium-"]
 


### PR DESCRIPTION
Fixes https://github.com/synthead/discord-adfree/issues/6!

Blocks the  "Add Super Reaction" menu item in the message context menu:

![image](https://github.com/synthead/discord-adfree/assets/820984/f1113ce0-8655-4043-afb8-a75f858de5d1)