### PR TITLE
Use class^="channel_" to block Nitro tab from DMs

### DIFF
--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -4,7 +4,7 @@
 
 
 ! Block Nitro in channel list.
-discord.com##li[class^="channel-"]:has(a[data-list-item-id$="___nitro"])
+discord.com##li[class^="channel_"]:has(a[data-list-item-id$="___nitro"])
 
 ! Block "gift" button in text input field.
 discord.com##button[aria-label="Send a gift"]


### PR DESCRIPTION
Fixes https://github.com/synthead/discord-adfree/issues/8!

Removes the "Nitro" tab from the DMs view.

Before:
![image](https://github.com/synthead/discord-adfree/assets/820984/9c19d21e-ea24-4ae5-8841-5fef2fa48ed2)

After:
![image](https://github.com/synthead/discord-adfree/assets/820984/eeb144a9-a790-48c3-95a1-8b8120068118)
