### PR TITLE
Block "Shop" in DM list

### DIFF
--- a/discord-adfree.txt
+++ b/discord-adfree.txt
@@ -23,3 +23,6 @@ discord.com##div[class*=" colorPremium-"]
 
 ! Block "Try out Nitro!" in user profile editor.
 discord.com##div[class^="premiumFeatureBorder-"]:has(div[class^="premiumBackground-"])
+
+! Block "Shop" in DM list.
+discord.com##ul[aria-label="Direct Messages"] > li > div > a[href="/shop"]:nth-ancestor(2)


### PR DESCRIPTION
Closes https://github.com/synthead/discord-adfree/issues/10!

This PR blocks the "Shop" link in the DM list: 

![image](https://github.com/synthead/discord-adfree/assets/820984/28d5dbc8-33a7-43d2-9048-112055942d92)